### PR TITLE
Added Trove classifiers for Python versions up to 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,10 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Systems Administration',
     ]


### PR DESCRIPTION
No review needed.
Tested on MacOS with Python 3.12.