### PR TITLE
Added handling of HTTP 422 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,8 +176,9 @@ jobs:
     # Note: This requires that in the branch protection rules for stable_*,
     #       the "Restrict pushes that create matching branches" checkmark is
     #       not set.
-    - name: Create new stable branch when releasing master branch
+    - name: "Create new stable branch ${{ steps.set-stable-branch.outputs.result }} when releasing master branch"
       if: steps.set-is-master-branch.outputs.result == 'true'
+      id: create-stable-branch
       uses: actions/github-script@v7
       with:
         script: |
@@ -189,3 +190,12 @@ jobs:
           })
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+    - name: Handle HTTP error 422 from creating the new stable branch
+      if: steps.set-is-master-branch.outputs.result == 'true' and steps.create-stable-branch.outputs.status == 422
+      run: |
+        echo "Error: Creating the new stable branch ${{ steps.set-stable-branch.outputs.result }} failed, but the publish still succeeded. Create the new stable branch manually:"
+        echo "git checkout master"
+        echo "git pull"
+        echo "git checkout -b ${{ steps.set-stable-branch.outputs.result }}"
+        echo "git push --set-upstream origin ${{ steps.set-stable-branch.outputs.result }}"

--- a/.github/workflows/try_branch.yml
+++ b/.github/workflows/try_branch.yml
@@ -1,0 +1,42 @@
+# This GitHub workflow will publish the package to Pypi and create a new stable branch when releasing the master branch.
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: publish
+
+on:
+  push:  # When pushing a tag
+    tags:
+    - "*a0"  # Only on tag for a new version
+
+jobs:
+  publish:
+    name: Try branch creation
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: "Create a branch"
+      id: create-branch
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: "refs/heads/try_branch",
+            sha: "${{ github.sha }}",
+          })
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+
+    - name: Handle HTTP error 422 from creating the branch
+      if: steps.create-branch.outputs.status == 422
+      run: |
+        echo "Error: Creating the branch failed. Create the branch manually:"
+        echo "git checkout master"
+        echo "git pull"
+        echo "git checkout -b try_branch"
+        echo "git push --set-upstream origin try_branch"

--- a/changes/noissue.http422.fix.rst
+++ b/changes/noissue.http422.fix.rst
@@ -1,0 +1,2 @@
+Dev: Added handling of HTTP error 422 when creating a new stable branch in
+the GitHub Actions publish workflow.


### PR DESCRIPTION
This PR also includes a workflow "try_branch" that is run when pushing a tag that ends with "a0", that reproduces the HTTP 422 issue. Test this workflow with and without enabling the "Restrict pushes that create matching branches" checkmark in the branch protection of `stable_*`.