### PR TITLE
Removed the pinning on typer version <0.17.0 with safety 3.6.1

### DIFF
--- a/changes/noissue.38.fix.rst
+++ b/changes/noissue.38.fix.rst
@@ -1,0 +1,1 @@
+Upgrade nltk to 3.9.1 to fix the wordnet error, see https://github.com/nltk/nltk/issues/3416

--- a/changes/noissue.68.fix.rst
+++ b/changes/noissue.68.fix.rst
@@ -1,0 +1,2 @@
+Removed the pinning of typer version to <0.17.0 with the new release of safety 3.6.1 and
+also upgraded minimum version of safety to be 3.6.1 to fix the issue with typer>=0.17.0, see  https://github.com/pyupio/safety/issues/778

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -80,7 +80,7 @@ incremental==22.10.0
 click-default-group==1.2.4
 
 # Safety CI by pyup.io
-safety==3.4.0
+safety==3.6.1
 safety-schemas==0.0.14
 dparse==0.6.4
 ruamel.yaml==0.17.21
@@ -88,9 +88,9 @@ click==8.0.2
 Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
-typer==0.12.1
-typer-cli==0.12.1
-typer-slim==0.12.1
+typer==0.16.0
+typer-cli==0.16.0
+typer-slim==0.16.0
 psutil==6.1.0
 
 # Bandit checker
@@ -126,7 +126,7 @@ Jinja2==3.1.6
 keyring==18.0.0
 levenshtein==0.25.1
 MarkupSafe==2.0
-nltk==3.9
+nltk==3.9.1
 pkginfo==1.4.2
 py==1.11.0
 requests-toolbelt==0.8.0

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -89,10 +89,9 @@ ruff>=0.3.5
 towncrier>=22.8.0
 
 # Safety CI by pyup.io
-# safety 3.4.0 supports marshmallow>=4.0.0, see https://github.com/pyupio/safety/issues/715
-# safety 3.4.0 started using httpx and tenacity
+# safety 3.6.1 fixes the issue with typer >=0.17.0, see https://github.com/pyupio/safety/issues/778
 # pydantic 2.8.0 fixes an install issue on Python 3.13.
-safety>=3.4.0
+safety>=3.6.1
 safety-schemas>=0.0.14
 dparse>=0.6.4
 ruamel.yaml>=0.17.21
@@ -100,10 +99,10 @@ click>=8.0.2
 Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
-# typer >=0.17.0 causes import issue for safety, see https://github.com/pyupio/safety/issues/778
-typer>=0.12.1,<0.17.0
-typer-cli>=0.12.1,<0.17.0
-typer-slim>=0.12.1,<0.17.0
+# safety 3.6.1 depends on typer>=0.16.0
+typer>=0.16.0
+typer-cli>=0.16.0
+typer-slim>=0.16.0
 # safety 3.4.0 depends on psutil~=6.1.0
 psutil~=6.1.0
 


### PR DESCRIPTION
* Typer version was pinned to 0.17.0 due to pyupio/safety#778
* The issue is fixed with safety 3.6.1
* We no longer need to pin that version
* Upgrade nltk to 3.9.1 to make it compatible with safety