### PR TITLE
1.1: Fixed pip-missing-reqs TypeError by pinning pip to <26.2

### DIFF
--- a/changes/noissue.pipcheckreqs.fix.rst
+++ b/changes/noissue.pipcheckreqs.fix.rst
@@ -1,0 +1,2 @@
+Development: Fixed that pip-missing-reqs raised TypeError by pinning pip
+to <26.2.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -110,8 +110,8 @@ bandit==1.7.8
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.24.0
-pip-check-reqs==2.4.3; python_version <= '3.11'
-pip-check-reqs==2.5.1; python_version >= '3.12'
+pip-check-reqs==2.4.3; python_version == '3.8'
+pip-check-reqs==2.5.6; python_version >= '3.9'
 
 
 # ------------------------------------------------------------------------------

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -9,7 +9,7 @@
 # Need to comment out pip==26.0.1 due to issue https://github.com/pyupio/safety/issues/847
 # pip==25.0; python_version == '3.8'
 # pip==26.0.1; python_version == '3.9'
-pip==26.1; python_version >= '3.10'
+pip==26.1.2; python_version >= '3.10'
 setuptools==70.0.0; python_version == '3.8'
 setuptools==78.1.1; python_version >= '3.9'
 # Note on not specifying 'setuptools-scm[toml]': Extras cannot be in constraints files

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -11,7 +11,8 @@
 
 pip>=25.0; python_version == '3.8'
 pip>=26.0.1; python_version == '3.9'
-pip>=26.1; python_version >= '3.10'
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'
 setuptools>=70.0.0; python_version == '3.8'
 setuptools>=78.1.1; python_version >= '3.9'
 setuptools-scm[toml]>=9.2.0

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -113,12 +113,11 @@ bandit>=1.7.8
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.24.0
-# pip-check-reqs 2.3.2 is needed to have proper support for pip<21.3.
-# pip-check-reqs 2.4.0 requires Python>=3.8.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
+# pip-check-reqs 2.5.0 dropped support for py38
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
-pip-check-reqs>=2.4.3,!=2.5.0; python_version <= '3.11'
-pip-check-reqs>=2.5.1; python_version >= '3.12'
+pip-check-reqs>=2.4.3,!=2.5.0; python_version == '3.8'
+pip-check-reqs>=2.5.6; python_version >= '3.9'
 
 
 # ------------------------------------------------------------------------------
@@ -128,3 +127,6 @@ pip-check-reqs>=2.5.1; python_version >= '3.12'
 # packaging is used by pytest, pip-check-reqs, sphinx
 # packaging>=20.5 is needed by pip-check-reqs 2.4.3 but it requires only packaging>=16.0
 packaging>=24.1
+
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'


### PR DESCRIPTION
Backports #278 into 1.1.